### PR TITLE
Restore zc.buildout compatibility

### DIFF
--- a/pyphen.py
+++ b/pyphen.py
@@ -28,7 +28,6 @@ Pure Python module to hyphenate text, inspired by Ruby's Text::Hyphen.
 from __future__ import unicode_literals
 
 import os
-import sys
 import re
 
 try:
@@ -36,6 +35,15 @@ try:
 except NameError:
     # Python3
     unichr = chr
+
+try:
+    import pkg_resources
+except ImportError:
+    # no setuptools installed
+    import sys
+    sys_root = sys.prefix
+else:
+    sys_root = pkg_resources.resource_filename('pyphen', '')
 
 
 __all__ = ('Pyphen', 'LANGUAGES', 'language_fallback')
@@ -51,7 +59,7 @@ parse = re.compile(r'(\d?)(\D?)').findall
 # - at <sys_root>/share/pyphen/dictionaries when Pyphen is installed
 # - at <project_root>/dictionaries when Pyphen is not installed
 dictionaries_roots = (
-    os.path.join(sys.prefix, 'share', 'pyphen', 'dictionaries'),
+    os.path.join(sys_root, 'share', 'pyphen', 'dictionaries'),
     os.path.join(os.path.dirname(__file__), 'dictionaries'))
 LANGUAGES = dict(
     (filename[5:-4], os.path.join(dictionaries_root, filename))

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ classifiers = [
 _dict_folder = os.path.join(os.path.dirname(__file__), 'dictionaries')
 setup(
     name='Pyphen',
-    version='0.8',
+    version='0.9dev',
     py_modules=['pyphen'],
     provides=['pyphen'],
     data_files=[(


### PR DESCRIPTION
In projects installed using [zc.buildout](http://www.buildout.org) the eggs are stored outside
sys.prefix. As pkg_resources (from setuptools) is always used in such
projects it can be used there to get the path to the installed egg.

I think fixing #3 broke the compatibility with zc.buildout.
