### PR TITLE
Add support for use when frozen

### DIFF
--- a/pyphen.py
+++ b/pyphen.py
@@ -48,12 +48,12 @@ parse = re.compile(r'(\d?)(\D?)').findall
 # - at <pkg_resources>/share/pyphen/dictionaries when Pyphen is in an egg
 try:
     import pkg_resources
-except ImportError:
-    dictionaries_roots = ()
-else:
     dictionaries_roots = (os.path.join(
         pkg_resources.resource_filename('pyphen', ''),
         'share', 'pyphen', 'dictionaries'),)
+except ImportError:
+    dictionaries_roots = ()
+
 finally:
     dictionaries_roots += (
         os.path.join(sys.prefix, 'share', 'pyphen', 'dictionaries'),


### PR DESCRIPTION
pkg_resources.resource_filename('pyphen', '') also throws ImportError when frozen.

When using py2exe or similar, modules are all wrapped on in a library.zip file and pkg_resources can't access them in the normal fashion and throws ImportError because it can't find a module named pyphen.
The modules works fine when frozen with this change so long as the dictionaries folder is bundled in the app folder next to the main exe, or installed in the system as per other path options in the file.