### PR TITLE
Update test environments to match stated support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ dictionaries and the libreoffice's repository for more details.
 http://cgit.freedesktop.org/libreoffice/dictionaries/tree/
 
 * Free software: GPL 2.0+/LGPL 2.1+/MPL 1.1 tri-license
-* For Python 3.5+, tested on CPython and PyPy
+* For Python 3.6+, tested on CPython and PyPy
 * Documentation: https://pyphen.org
 * Changelog: https://github.com/Kozea/pyphen/releases
 * Code, issues, tests: https://github.com/Kozea/pyphen

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
-envlist = py26, py27, py32, py33, py34
+envlist = py36,py37,py38,py39
 
 [testenv]
 deps = nose-cov
 commands = nosetests []
-


### PR DESCRIPTION
Version 0.10.0 [claims Python 3.6–3.9 support](https://github.com/Kozea/Pyphen/commit/36190b67197dceb458c6ef28431bd1b1209805ee); this should be matched in tox.ini (and in README).

I don’t have interpreters <3.9 on my machine, but `tox` runs and passes the suite in 3.9 at least.