### PR TITLE
Make language parameter case-insensitive

### DIFF
--- a/pyphen/__init__.py
+++ b/pyphen/__init__.py
@@ -39,6 +39,8 @@ for filename in sorted(os.listdir(dictionaries_root)):
         if short_name not in LANGUAGES:
             LANGUAGES[short_name] = full_path
 
+LANGUAGES_LOWERCASE = {name.lower(): name for name in LANGUAGES}
+
 
 def language_fallback(language):
     """Get a fallback language available in our dictionaries.
@@ -49,11 +51,11 @@ def language_fallback(language):
     including scripts for languages with multiple regions available.
 
     """
-    parts = language.replace('-', '_').split('_')
+    parts = language.replace('-', '_').lower().split('_')
     while parts:
         language = '_'.join(parts)
-        if language in LANGUAGES:
-            return language
+        if language in LANGUAGES_LOWERCASE:
+            return LANGUAGES_LOWERCASE[language]
         parts.pop()
 
 

--- a/tests/test_pyphen.py
+++ b/tests/test_pyphen.py
@@ -109,6 +109,7 @@ def test_fallback():
     assert pyphen.language_fallback('en_US') == 'en_US'
     assert pyphen.language_fallback('en_FR') == 'en'
     assert pyphen.language_fallback('sr-Latn') == 'sr_Latn'
+    assert pyphen.language_fallback('SR-LATN') == 'sr_Latn'
     assert pyphen.language_fallback('sr-Cyrl') == 'sr'
     assert pyphen.language_fallback('fr-Latn-FR') == 'fr'
     assert pyphen.language_fallback('en-US_variant1-x') == 'en_US'


### PR DESCRIPTION
This pull request makes the language parameter case-insensitive so that users do not have to worry about the case problem.

e.g. `en_us`, `sr_LATN` are both valid language codes now (before they should be cased as `en_US` and `sr_Latn` exactly).