### PR TITLE
Update Hungarian hyphenation dictionary

### DIFF
--- a/pyphen/dictionaries/hyph_hu_HU.dic
+++ b/pyphen/dictionaries/hyph_hu_HU.dic
@@ -102255,3 +102255,6 @@ giccsen1ké
 .mobila1da
 .középál1lá
 .tec2h
+.ké2r1ü2g
+.ké1rü2
+.k8é7r8ü8g7m8


### PR DESCRIPTION
This PR updates the Hungarian hyphenation dictionary according to [this commit](https://github.com/LibreOffice/dictionaries/commit/2ae8fab6fe32bbd3d9817d41a823dc3a9dc6a07f).