### PR TITLE
Add Sanskrit dictionary

### DIFF
--- a/pyphen/dictionaries/hyph_sa_IN.dic
+++ b/pyphen/dictionaries/hyph_sa_IN.dic
@@ -1,0 +1,114 @@
+UTF-8
+LEFTHYPHENMIN 3
+RIGHTHYPHENMIN 4
+COMPOUNDLEFTHYPHENMIN 2
+COMPOUNDRIGHTHYPHENMIN 3
+% GENERAL RULE
+% Do not break either side of ZERO-WIDTH JOINER  (U+200D)
+2‍2
+% Break after ZERO-WIDTH NON JOINER  (U+200C)
+‌1
+% Break before or after any independent vowel.
+1अ1
+1आ1
+1इ1
+1ई1
+1उ1
+1ऊ1
+1ऋ1
+1ॠ1
+1ऌ1
+1ॡ1
+1ए1
+1ऐ1
+1ओ1
+1औ1
+% Break after any dependent vowel but not before.
+ा1
+ि1
+ी1
+ु1
+ू1
+ृ1
+ॄ1
+ॢ1
+ॣ1
+े1
+ै1
+ो1
+ौ1
+% Break before or after any consonant.
+1क
+1ख
+1ग
+1घ
+1ङ
+1च
+1छ
+1ज
+1झ
+1ञ
+1ट
+1ठ
+1ड
+1ढ
+1ण
+1त
+1थ
+1द
+1ध
+1न
+1प
+1फ
+1ब
+1भ
+1म
+1य
+1र
+1ल
+1ळ
+1व
+1श
+1ष
+1स
+1ह
+% Do not break before chandrabindu, anusvara, visarga, avagraha
+% and accents.
+2ँ
+2ं
+2ः
+2ऽ
+2॑
+2॒
+% Do not break either side of virama (may be within conjunct).
+2्2
+अति1
+अधि1
+अन1
+अनु1
+अन्1
+अप1
+अपि1
+अभि1
+अव1
+1इय
+उद्1
+उप1
+1का
+चिर्1
+1त्र
+1त्व
+दुर्1
+दुस्1
+नि1
+निर्1
+निस्1
+पर1
+परि1
+प्र1
+प्रति1
+1ली
+1वत्
+वि1
+सम्1
+सु1


### PR DESCRIPTION
This PR adds a Sanskrit dictionary according to [this commit](https://github.com/LibreOffice/dictionaries/commit/5b8116e5e8a1ce761f929f8dad1a91ff6ceb5ccc#diff-491edce1fa2342305896f52b1c2b13b0a4ee4e9ba4dc8f697083a4694e0ecb28).

No README file could be found in the LibreOffice dictionaries repo.