### PR TITLE
Remove extra blank lines at the end of some license files

### DIFF
--- a/pyphen/dictionaries/README_hyph_NO.txt
+++ b/pyphen/dictionaries/README_hyph_NO.txt
@@ -9,4 +9,3 @@ Author:   The spell-norwegian project, <URL:https://alioth.debian.org/projects/s
 
 HYPH nn NO nn_NO
 HYPH nb NO nb_NO
-

--- a/pyphen/dictionaries/README_hyph_de.txt
+++ b/pyphen/dictionaries/README_hyph_de.txt
@@ -39,4 +39,3 @@ https://www.openoffice.org/lingucomponent/hyphenator.html als Teil
 der Datei altlinux_Hyph.zip heruntergeladen werden kann.
 Die Original-Trennmuster können hier heruntergeladen werden:
 https://www.ctan.org/tex-archive/language/hyphenation/dehyphn.tex
-

--- a/pyphen/dictionaries/README_hyph_el_GR.txt
+++ b/pyphen/dictionaries/README_hyph_el_GR.txt
@@ -8,4 +8,3 @@ License:	LGPL
 Author:		InterZone <info@interzone.gr>
 
 This dictionary should be usable only for monotonic Greek (not polytonics, neither archaic). There may be some problems with words starting with accented vowels, feedback is welcome. Words in quotes do not hyphenate, but it seems like a problem with OpenOffice and not the hyphenation dictionary.
-

--- a/pyphen/dictionaries/README_hyph_eu.txt
+++ b/pyphen/dictionaries/README_hyph_eu.txt
@@ -73,4 +73,3 @@
 % the patterns. These and other changes will have to be re-enacted when
 % Basque be established as the current language. See the babel docs if
 % you don't understand this.
-

--- a/pyphen/dictionaries/README_hyph_it_IT.txt
+++ b/pyphen/dictionaries/README_hyph_it_IT.txt
@@ -25,4 +25,3 @@ Questo dizionario dovrebbe essere valido anche per altre varianti di italiano
 ===============================================================================
 
 HYPH it IT hyph_it_IT_v2
-

--- a/pyphen/dictionaries/README_hyph_pt_PT.txt
+++ b/pyphen/dictionaries/README_hyph_pt_PT.txt
@@ -11,4 +11,3 @@ This dictionary is based on syllable matching patterns and therefore should
 be usable under other variations of Portuguese.
 
 HYPH pt PT hyph_pt_PT
-

--- a/pyphen/dictionaries/README_hyph_uk_UA.txt
+++ b/pyphen/dictionaries/README_hyph_uk_UA.txt
@@ -20,4 +20,3 @@
 % You should have received a copy of the GNU General Public License
 % along with this program; if not, write to the Free Software
 % Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
-


### PR DESCRIPTION
This PR removes extra blank lines at the end of some license files for better consistency.

All license files now end with only one blank line.